### PR TITLE
ant-Installation, Dependency pinning + missing ini file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM php:5.6-fpm
 
-RUN apt-get update && apt-get install -y \
-        openjdk-7-jre-headless \
+RUN mkdir -p /usr/share/man/man1 \
+    && apt-get update \
+    && apt-get install -y \
         ant \
         vim \
         git

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
-        libpng12-dev \
-        libmysqlclient18 \
+        libpng-dev \
+        libmariadbclient18 \
         libicu-dev \
     && docker-php-ext-install -j$(nproc) iconv mcrypt \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN apt-get update && apt-get install -y libmemcached-dev \
         libmagickcore-6.q16-3 \
         libmagickwand-6.q16-3 \
     && pecl install memcached-2.2.0 \
-    && pecl install imagick \
-    && pecl install xdebug \
+    && pecl install imagick-3.4.3 \
+    && pecl install xdebug-2.5.5 \
     && docker-php-ext-enable memcached \
     && docker-php-ext-enable imagick \
     && docker-php-ext-enable xdebug \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && apt-get install -y libmemcached-dev \
     && docker-php-ext-enable xdebug \
     && docker-php-ext-enable opcache
 
-ADD php/symfony.ini /usr/local/etc/php/conf.d/symfony.ini
+ADD rootfs/ /
 
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 RUN php composer-setup.php

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update && apt-get install -y libmemcached-dev \
         libgomp1 \
         libmagickwand-dev \
         libmagickcore-dev \
-        libmagickcore-6.q16-2 \
-        libmagickwand-6.q16-2 \
+        libmagickcore-6.q16-3 \
+        libmagickwand-6.q16-3 \
     && pecl install memcached-2.2.0 \
     && pecl install imagick \
     && pecl install xdebug \

--- a/rootfs/usr/local/etc/php/conf.d/symfony.ini
+++ b/rootfs/usr/local/etc/php/conf.d/symfony.ini
@@ -1,0 +1,7 @@
+date.timezone="Europe/Berlin"
+memory_limit=-1
+xdebug.remote_enable=1
+xdebug.remote_host=10.200.10.1
+realpath_cache_size=4096K
+realpath_cache_ttl=600
+opcache.max_accelerated_files=20000


### PR DESCRIPTION
* Add missing symfony.ini file (from php56) branch
* Pin imagemagick + xdebug PECL package versions
* Update package dependencies for PHP extension imagemagick
* Update package dependencies for PHP extensions GD + mysql
* Create manpage directory to allow ant/jre installation

Build and tested against local WPW copy.

`libmariadbclient` package seems to work fine. Had mixed feelings about this, but fetching Oracle MySQL stuff is probably bloated.

What do you think?